### PR TITLE
Downgrade Microsoft.CodeAnalysis.CSharp version

### DIFF
--- a/src/ApiFirstMediatR.Generator/ApiFirstMediatR.Generator.csproj
+++ b/src/ApiFirstMediatR.Generator/ApiFirstMediatR.Generator.csproj
@@ -29,7 +29,7 @@
         <PackageReference Include="CaseExtensions" Version="1.1.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="IoC.Container" Version="1.3.8" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.OpenApi" Version="1.6.2" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.2" GeneratePathProperty="true" PrivateAssets="all" />


### PR DESCRIPTION
Downgrade Microsoft.CodeAnalysis.CSharp to lowest version that targets .NET 6. Ref: #69 